### PR TITLE
Exclude web from init

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,7 +26,7 @@ void main() {
   // );
   appLogger.debug("Starting app");
   WidgetsFlutterBinding.ensureInitialized();
-  Hive.init(Directory(".config/obs_scorer_client/").absolute.path);
+  if (!kIsWeb) Hive.init(Directory(".config/obs_scorer_client/").absolute.path);
   unawaited(Future(() async {
     await Hive.openBox("settings");
     await Settings.init(cacheProvider: HiveSettingsCache("settings"));


### PR DESCRIPTION
Web breaks if `Hive.init` runs.

So, this checks if it `!kIsWeb`, and *only then* runs `Hive.init`.