### PR TITLE
Settings sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ This version of OBS Scorer Client is a **feature-complete full rewrite** of my o
 
 OBS Scorer Client can do the following when paired with a recent version of OBS Studio (which comes with obs-websockets built-in, running protocol v5; **\*** indicates a new feature over legacy):
 * Show a convenient summary of the scoreboard front and center.**\***
-* Show, increment**\***, and manually change the home and away scores.
+* Show, increment **\***, and manually change the home and away scores.
 * Show and increment the home and away timeouts.
 * Show, increment, manually change, start, and stop the game clock.
 * Change the quarter/period between 1st, 2nd, 3rd, 4th, and overtime.
 * Football: Change the current downs and distance (i.e. 1st & 10) with handy shortcuts.
 * Configure the source names to use any text sources you provide.
+* Send some auxiliary "top text" to OBS.
+* Hide or disable controls that can't be used (due to unset settings).**\***
+* Push and pull settings to OBS. This has been **improved** from legacy: you don't have to create or name a "settings sync source" anymore.

--- a/lib/src/sync.dart
+++ b/lib/src/sync.dart
@@ -1,0 +1,35 @@
+import 'package:hive/hive.dart';
+import 'package:obs_websocket/obs_websocket.dart';
+import 'package:slugify/slugify.dart';
+
+/// Push settings to OBS.
+Future<void> pushSettings(Box box, ObsWebSocket obs) async {
+  final sceneCollection = await obs.config.getSceneCollectionList().then((value) => value.currentSceneCollectionName);
+  await obs.config.setPersistentData(
+    realm: "OBS_WEBSOCKET_DATA_REALM_PROFILE",
+    slotName: "OBS_SCORER_CLIENT_PRESET_${slugify(sceneCollection, delimiter: '_').toUpperCase()}",
+    slotValue: box.toMap()
+    ..removeWhere((key, value) => key is String && key.startsWith("connection.")) // remove connection settings
+  );
+}
+
+/// Pull settings from OBS.
+Future<void> pullSettings(Box box, ObsWebSocket obs) async {
+  final sceneCollection = await obs.config.getSceneCollectionList().then((value) => value.currentSceneCollectionName);
+  late final dynamic settings;
+  try {
+    settings = await obs.config.getPersistentData(
+      realm: "OBS_WEBSOCKET_DATA_REALM_PROFILE",
+      slotName: "OBS_SCORER_CLIENT_PRESET_${slugify(sceneCollection, delimiter: '_').toUpperCase()}"
+    );
+  } catch(e) {
+    late final String profile;
+    try {
+      profile = await obs.config.getProfileList().then((value) => value.currentProfileName);
+    } catch(e) {
+      throw Exception("Could not get current profile. OBS connection probably failed");
+    }
+    throw Exception("No settings found in profile '$profile' for scene collection '$sceneCollection'.");
+  }
+  await box.putAll(settings);
+}

--- a/lib/src/sync.dart
+++ b/lib/src/sync.dart
@@ -21,7 +21,7 @@ Future<void> pullSettings(Box box, ObsWebSocket obs) async {
     settings = await obs.config.getPersistentData(
       realm: "OBS_WEBSOCKET_DATA_REALM_PROFILE",
       slotName: "OBS_SCORER_CLIENT_PRESET_${slugify(sceneCollection, delimiter: '_').toUpperCase()}"
-    );
+    ).then((value) => value["slotValue"]);
   } catch(e) {
     late final String profile;
     try {

--- a/lib/views/settings.dart
+++ b/lib/views/settings.dart
@@ -279,34 +279,39 @@ class _SettingsViewState extends State<SettingsView> {
           leading: const Icon(Icons.code),
           child: const LogView(),
         ),
-        ListTile(
-          title: Text("Log out", style: headerTextStyle(context)?.copyWith(color: Colors.red)),
-          leading: const Icon(Icons.logout),
-          iconColor: Colors.red,
-          textColor: Colors.red,
-          onTap: () {
-            showDialog(context: context, builder: (context) => AlertDialog(
-              title: const Text("Are you sure you want to log out?"),
-              actions: [
-                TextButton(
-                  child: const Text("Cancel"),
-                  onPressed: () => Navigator.pop(context, false),
-                ),
-                TextButton(
-                  child: const Text("Log out"),
-                  onPressed: () {
-                    Navigator.pop(context, true);
-                  },
-                ),
-              ],
-            )).then((value) {
-              if (!value) return;
-              Hive.box("settings").delete(ConnectionSetting.address);
-              Hive.box("settings").delete(ConnectionSetting.password);
-              Navigator.of(context).popUntil((route) => route.isFirst);
-              Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => const LoginView()));
-            });
-          },
+        Consumer(
+          builder: (context, ref, _) {
+            return ListTile(
+              title: Text("Log out", style: headerTextStyle(context)?.copyWith(color: Colors.red)),
+              leading: const Icon(Icons.logout),
+              iconColor: Colors.red,
+              textColor: Colors.red,
+              onTap: () {
+                showDialog(context: context, builder: (context) => AlertDialog(
+                  title: const Text("Are you sure you want to log out?"),
+                  content: const Text("Any unpushed settings will be lost."),
+                  actions: [
+                    TextButton(
+                      child: const Text("Cancel"),
+                      onPressed: () => Navigator.pop(context, false),
+                    ),
+                    TextButton(
+                      child: const Text("Log out"),
+                      onPressed: () {
+                        Navigator.pop(context, true);
+                      },
+                    ),
+                  ],
+                )).then((value) {
+                  if (!value) return;
+                  Hive.box("settings").clear();
+                  ref.read(socketProvider).value?.close();
+                  Navigator.of(context).popUntil((route) => route.isFirst);
+                  Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => const LoginView()));
+                });
+              },
+            );
+          }
         ),
       ],
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -588,6 +588,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  slugify:
+    dependency: "direct main"
+    description:
+      name: slugify
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   source_gen:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   loggy: ^2.0.1+1
   pinelogger: ^1.1.0
   pinelogger_flutter: ^1.0.0
+  slugify: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: obs_scorer_client
 description: Easily change custom scoreboards in OBS.
 publish_to: 'none'
 
-version: 2.0.0+1
+version: 2.1.0+2
 
 environment:
   sdk: '>=2.18.0-271.7.beta <3.0.0'


### PR DESCRIPTION
This feature should have been in 2.0 but I forgot to add it. Now it's in 2.1; this PR also bumps the version to 2.1 and mentions the few things I forgot to put in the README (this is not best practice).

Added:
* Settings sync push and pull buttons in Settings.

Login related changes:
* If settings fail to sync when logging in, it will silently fail.
Having nothing to sync is an expected behavior.
If you suspect something did, in fact, go wrong, you can check the Logs,
but I think it'll just tell you that it failed.
* Logging in now forces the socket to start at least twice. I think
it closes properly both times.

Logout related changes:
* Instead of just removing the connection values, it now clears Hive.
* The "are you sure" prompt warns you that any unpushed settings will be
lost-- which, to my knowledge, is the only real danger to logging out.